### PR TITLE
Fix: multiple content-type headers in requests

### DIFF
--- a/src/main/java/io/github/sashirestela/openai/http/HttpProcessor.java
+++ b/src/main/java/io/github/sashirestela/openai/http/HttpProcessor.java
@@ -72,6 +72,7 @@ public class HttpProcessor {
     ReturnType returnType = methodMetadata.getReturnType();
     boolean isMultipart = methodMetadata.isMultipart();
     Object bodyObject = calculateBodyObject(methodMetadata, arguments);
+    List<String> headers = new ArrayList<>(this.headers);
     headers.addAll(calculateHeaderContentType(bodyObject, isMultipart));
     String[] headersArray = headers.toArray(new String[0]);
     HttpConnector httpConnector = HttpConnector.builder()

--- a/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
+++ b/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
@@ -1,16 +1,28 @@
 package io.github.sashirestela.openai;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
+import io.github.sashirestela.openai.domain.chat.ChatRequest;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 public class SimpleOpenAITest {
 
   @Mock
-  HttpClient httpClient;
+  HttpClient httpClient = mock(HttpClient.class);
 
   @Test
   void shouldCreateAnIstanceOfAudioServiceWhenCallingSimpleOpenAI() {
@@ -24,6 +36,36 @@ public class SimpleOpenAITest {
     SimpleOpenAI simpleOpenAI = SimpleOpenAI.builder().apiKey("apiKey").build();
     OpenAI.ChatCompletions chatService = simpleOpenAI.chatCompletions();
     assertNotNull(chatService);
+  }
+
+  @Test
+  void shouldNotDuplicateContentTypeHeaderWhenCallingSimpleOpenAI() {
+    var chatService = SimpleOpenAI.builder()
+            .apiKey("apiKey")
+            .httpClient(httpClient)
+            .build()
+            .chatCompletions();
+
+    // When
+    final int NO_OF_REQUESTS = 2;
+    Mockito.when(httpClient.sendAsync(any(), any()))
+            .thenReturn(completedFuture(mock(HttpResponse.class)));
+
+    repeat(NO_OF_REQUESTS, () -> {
+      var chatRequest = ChatRequest.builder()
+              .model("model")
+              .messages(List.of())
+              .build();
+      chatService.create(chatRequest);
+    });
+
+    // Then
+    ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient, times(NO_OF_REQUESTS))
+            .sendAsync(requestCaptor.capture(), any());
+
+    HttpRequest actualRequest = requestCaptor.getAllValues().get(NO_OF_REQUESTS - 1);
+    assertEquals(1, actualRequest.headers().allValues("Content-Type").size(), "Contains Content-Type header exactly once");
   }
 
   @Test
@@ -73,5 +115,10 @@ public class SimpleOpenAITest {
     SimpleOpenAI simpleOpenAI = SimpleOpenAI.builder().apiKey("apiKey").httpClient(httpClient).build();
     OpenAI.Moderations moderationService = simpleOpenAI.moderations();
     assertNotNull(moderationService);
+  }
+
+  private static void repeat(int times, Runnable action) {
+    for (int i = 0; i < times; i++)
+      action.run();
   }
 }


### PR DESCRIPTION
I've found an issue that after each call to OpenAI API the Content-Type header in the request is duplicated. After few requests the transmitted headers may look as follows:

> Sep 05, 2023 9:20:07 PM jdk.internal.net.http.Http2Connection encodeHeaders
INFO: HEADERS: HEADERS FRAME (stream=13)
    :authority: api.openai.com
    :method: POST
    :path: /v1/chat/completions
    :scheme: https
    content-length: 4722
    User-Agent: Java-http-client/20.0.2
    Authorization: Bearer <...>
    Content-Type: application/json
    Content-Type: application/json
    Content-Type: application/json
    Content-Type: application/json
    Content-Type: application/json
    Content-Type: application/json
    Content-Type: application/json

ultimately leading to the OpenAI API error:

> HTTP 500 - limit request headers fields

Fix PR is provided.