### PR TITLE
Make ChatRequest, CompletionRequest, and audio requests fully immutable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <!-- Dependencies Versions -->
     <slf4j.version>[2.0.9,3.0.0)</slf4j.version>
-    <cleverclient.version>0.6.2</cleverclient.version>
+    <cleverclient.version>0.7.0</cleverclient.version>
     <lombok.version>[1.18.30,2.0.0)</lombok.version>
     <jackson.version>[2.15.2,3.0.0)</jackson.version>
     <json.schema.version>[4.31.1,5.0.0)</json.schema.version>

--- a/src/main/java/io/github/sashirestela/openai/OpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/OpenAI.java
@@ -6,14 +6,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import io.github.sashirestela.cleverclient.annotation.Body;
-import io.github.sashirestela.cleverclient.annotation.DELETE;
-import io.github.sashirestela.cleverclient.annotation.GET;
-import io.github.sashirestela.cleverclient.annotation.Multipart;
-import io.github.sashirestela.cleverclient.annotation.POST;
-import io.github.sashirestela.cleverclient.annotation.Path;
-import io.github.sashirestela.cleverclient.annotation.Query;
-import io.github.sashirestela.cleverclient.annotation.Resource;
+import io.github.sashirestela.cleverclient.annotation.*;
 import io.github.sashirestela.openai.domain.OpenAIDeletedResponse;
 import io.github.sashirestela.openai.domain.OpenAIGeneric;
 import io.github.sashirestela.openai.domain.audio.AudioRespFmt;
@@ -97,7 +90,7 @@ public interface OpenAI {
 
         @Multipart
         @POST("/transcriptions")
-        CompletableFuture<AudioResponse> transcribeWithOptions(@Body AudioTranscribeRequest audioRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<AudioResponse> transcribeWithOptions(@Body AudioTranscribeRequest audioRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Translates audio into English. Response as object.
@@ -112,7 +105,7 @@ public interface OpenAI {
 
         @Multipart
         @POST("/translations")
-        CompletableFuture<AudioResponse> translateWithOptions(@Body AudioTranslateRequest audioRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<AudioResponse> translateWithOptions(@Body AudioTranslateRequest audioRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Transcribes audio into the input language. Response as plain text.
@@ -127,7 +120,7 @@ public interface OpenAI {
 
         @Multipart
         @POST("/transcriptions")
-        CompletableFuture<String> transcribePlainWithOptions(@Body AudioTranscribeRequest audioRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<String> transcribePlainWithOptions(@Body AudioTranscribeRequest audioRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Translates audio into English. Response as plain text.
@@ -142,7 +135,7 @@ public interface OpenAI {
 
         @Multipart
         @POST("/translations")
-        CompletableFuture<String> translatePlainWithOptions(@Body AudioTranslateRequest audioRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<String> translatePlainWithOptions(@Body AudioTranslateRequest audioRequest, @BodyPart Map<String, ?> requestOptions);
 
     }
 
@@ -168,7 +161,7 @@ public interface OpenAI {
         }
 
         @POST
-        CompletableFuture<ChatResponse> createWithOptions(@Body ChatRequest chatRequest, @Body Map<String, Object> requestOptions);
+        CompletableFuture<ChatResponse> createWithOptions(@Body ChatRequest chatRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Creates a model response for the given chat conversation. Streaming Mode.
@@ -182,7 +175,7 @@ public interface OpenAI {
         }
 
         @POST
-        CompletableFuture<Stream<ChatResponse>> createStreamWithOptions(@Body ChatRequest chatRequest, @Body Map<String, Object> requestOptions);
+        CompletableFuture<Stream<ChatResponse>> createStreamWithOptions(@Body ChatRequest chatRequest, @BodyPart Map<String, ?> requestOptions);
 
     }
 
@@ -210,7 +203,7 @@ public interface OpenAI {
         }
 
         @POST
-        CompletableFuture<CompletionResponse> createWithOptions(@Body CompletionRequest completionRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<CompletionResponse> createWithOptions(@Body CompletionRequest completionRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Creates a completion for the provided prompt and parameters. Streaming mode.
@@ -225,7 +218,7 @@ public interface OpenAI {
         }
 
         @POST
-        CompletableFuture<Stream<CompletionResponse>> createStreamWithOptions(@Body CompletionRequest completionRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<Stream<CompletionResponse>> createStreamWithOptions(@Body CompletionRequest completionRequest, @BodyPart Map<String, ?> requestOptions);
 
     }
 
@@ -283,7 +276,7 @@ public interface OpenAI {
         }
 
         @GET
-        CompletableFuture<OpenAIGeneric<FileResponse>> getListWithOptions(@Body Map<String, ?> requestOptions);
+        CompletableFuture<OpenAIGeneric<FileResponse>> getListWithOptions(@BodyPart Map<String, ?> requestOptions);
 
         /**
          * Returns information about a specific file.
@@ -351,7 +344,7 @@ public interface OpenAI {
         CompletableFuture<OpenAIGeneric<FineTuningResponse>> getListWithOptions(
                 @Query("limit") Integer limit,
                 @Query("after") String after,
-                @Body Map<String, ?> requestOptions);
+                @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Get info about a fine-tuning job.
@@ -380,7 +373,7 @@ public interface OpenAI {
                 @Path("fineTuningId") String fineTuningId,
                 @Query("limit") Integer limit,
                 @Query("after") String after,
-                @Body Map<String, ?> requestOptions);
+                @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Immediately cancel a fine-tune job.
@@ -415,7 +408,7 @@ public interface OpenAI {
         }
 
         @POST("/generations")
-        CompletableFuture<OpenAIGeneric<ImageResponse>> createWithOptions(@Body ImageRequest imageRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<OpenAIGeneric<ImageResponse>> createWithOptions(@Body ImageRequest imageRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Creates an edited or extended image given an original image and a prompt.
@@ -430,7 +423,7 @@ public interface OpenAI {
 
         @Multipart
         @POST("/edits")
-        CompletableFuture<OpenAIGeneric<ImageResponse>> createEditsWithOptions(@Body ImageEditsRequest imageRequest, @Body Map<String, ?> requestOptions);
+        CompletableFuture<OpenAIGeneric<ImageResponse>> createEditsWithOptions(@Body ImageEditsRequest imageRequest, @BodyPart Map<String, ?> requestOptions);
 
         /**
          * Creates a variation of a given image.
@@ -447,7 +440,7 @@ public interface OpenAI {
         @POST("/variations")
         CompletableFuture<OpenAIGeneric<ImageResponse>> createVariationsWithOptions(
                 @Body ImageVariationsRequest imageRequest,
-                @Body Map<String, ?> requestOptions);
+                @BodyPart Map<String, ?> requestOptions);
     }
 
     /**
@@ -471,7 +464,7 @@ public interface OpenAI {
         }
 
         @GET
-        CompletableFuture<OpenAIGeneric<ModelResponse>> getListWithOptions(@Body Map<String, ?> requestOptions);
+        CompletableFuture<OpenAIGeneric<ModelResponse>> getListWithOptions(@BodyPart Map<String, ?> requestOptions);
 
         /**
          * Retrieves a model instance, providing basic information about the model such

--- a/src/main/java/io/github/sashirestela/openai/OpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/OpenAI.java
@@ -6,7 +6,15 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import io.github.sashirestela.cleverclient.annotation.*;
+import io.github.sashirestela.cleverclient.annotation.Body;
+import io.github.sashirestela.cleverclient.annotation.BodyPart;
+import io.github.sashirestela.cleverclient.annotation.DELETE;
+import io.github.sashirestela.cleverclient.annotation.GET;
+import io.github.sashirestela.cleverclient.annotation.Multipart;
+import io.github.sashirestela.cleverclient.annotation.POST;
+import io.github.sashirestela.cleverclient.annotation.Path;
+import io.github.sashirestela.cleverclient.annotation.Query;
+import io.github.sashirestela.cleverclient.annotation.Resource;
 import io.github.sashirestela.openai.domain.OpenAIDeletedResponse;
 import io.github.sashirestela.openai.domain.OpenAIGeneric;
 import io.github.sashirestela.openai.domain.audio.AudioRespFmt;

--- a/src/main/java/io/github/sashirestela/openai/domain/audio/AudioTranslateRequest.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/audio/AudioTranslateRequest.java
@@ -30,8 +30,4 @@ public class AudioTranslateRequest {
     @JsonInclude(Include.NON_NULL)
     protected Double temperature;
 
-    public void setResponseFormat(AudioRespFmt responseFormat) {
-        this.responseFormat = responseFormat;
-    }
-
 }

--- a/src/main/java/io/github/sashirestela/openai/domain/chat/ChatRequest.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/chat/ChatRequest.java
@@ -65,8 +65,4 @@ public class ChatRequest {
     @JsonInclude(Include.NON_NULL)
     private String user;
 
-    public void setStream(boolean stream) {
-        this.stream = stream;
-    }
-
 }

--- a/src/main/java/io/github/sashirestela/openai/domain/completion/CompletionRequest.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/completion/CompletionRequest.java
@@ -69,8 +69,4 @@ public class CompletionRequest {
     @JsonInclude(Include.NON_NULL)
     private String user;
 
-    public void setStream(boolean stream) {
-        this.stream = stream;
-    }
-
 }

--- a/src/main/java/io/github/sashirestela/openai/function/FunctionExecutor.java
+++ b/src/main/java/io/github/sashirestela/openai/function/FunctionExecutor.java
@@ -49,7 +49,7 @@ public class FunctionExecutor {
         }
         try {
             var function = mapFunctions.get(functionName);
-            var object = JsonUtil.jsonToObject(functionToCall.getArguments(), function.getFunctionalClass());
+            var object = JsonUtil.jsonToObjectStrict(functionToCall.getArguments(), function.getFunctionalClass());
             return (T) object.execute();
         } catch (RuntimeException e) {
             throw new SimpleUncheckedException("Cannot execute the function {0}.", functionName, e);

--- a/src/test/java/io/github/sashirestela/openai/domain/audio/AudioFilterTest.java
+++ b/src/test/java/io/github/sashirestela/openai/domain/audio/AudioFilterTest.java
@@ -4,28 +4,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.jupiter.api.BeforeAll;
+import io.github.sashirestela.openai.test.captors.CapturedValues;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.github.sashirestela.openai.SimpleOpenAI;
 import io.github.sashirestela.openai.SimpleUncheckedException;
+import org.mockito.ArgumentCaptor;
 
 class AudioFilterTest {
 
-    static SimpleOpenAI openAI;
-    static HttpClient httpClient = mock(HttpClient.class);
+    SimpleOpenAI openAI;
+    HttpClient httpClient = mock(HttpClient.class);
 
-    @BeforeAll
+    @BeforeEach
     @SuppressWarnings("unchecked")
-    static void setup() {
+    void setup() {
         openAI = SimpleOpenAI.builder()
                 .apiKey("apiKey")
                 .httpClient(httpClient)
@@ -35,13 +37,16 @@ class AudioFilterTest {
     }
 
     @Test
-    void shouldSetRespFmtToTextWhenCallingTranscribePlainMethodOfAudioServiceWithoutRespFmt() {
+    void shouldSendRespFmtTextWhenCallingTranscribePlainMethodOfAudioServiceWithoutRespFmt() {
         var audioRequest = AudioTranscribeRequest.builder()
                 .file(Path.of("src/demo/resources/hello_audio.mp3"))
                 .model("test_model")
                 .build();
         openAI.audios().transcribePlain(audioRequest);
-        assertEquals(AudioRespFmt.TEXT, audioRequest.getResponseFormat());
+
+        var httpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).sendAsync(httpRequest.capture(), any());
+        assertContainsText(AudioRespFmt.TEXT, httpRequest);
     }
 
     @Test
@@ -74,7 +79,15 @@ class AudioFilterTest {
                 .model("test_model")
                 .build();
         openAI.audios().transcribe(audioRequest);
-        assertEquals(AudioRespFmt.JSON, audioRequest.getResponseFormat());
+
+        var httpRequest = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).sendAsync(httpRequest.capture(), any());
+        assertContainsText(AudioRespFmt.JSON, httpRequest);
+    }
+
+    static void assertContainsText(AudioRespFmt responseFormat, ArgumentCaptor<HttpRequest> httpRequest) {
+        String requestBody = CapturedValues.getRequestBodyAsString(httpRequest);
+        assertTrue(requestBody.contains( responseFormat.name().toLowerCase() ), "Should contain " + requestBody + " in HttpRequest");
     }
 
     @Test

--- a/src/test/java/io/github/sashirestela/openai/domain/audio/AudioFilterTest.java
+++ b/src/test/java/io/github/sashirestela/openai/domain/audio/AudioFilterTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;

--- a/src/test/java/io/github/sashirestela/openai/test/captors/CapturedValues.java
+++ b/src/test/java/io/github/sashirestela/openai/test/captors/CapturedValues.java
@@ -1,0 +1,44 @@
+package io.github.sashirestela.openai.test.captors;
+
+import org.mockito.ArgumentCaptor;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Flow;
+
+public class CapturedValues {
+
+    public static String getRequestBodyAsString(ArgumentCaptor<HttpRequest> httpRequest) {
+        // be very sure that nobody else is concurrently
+        // subscribed to the body publisher when executing this code
+        return httpRequest.getValue().bodyPublisher().map(p -> {
+            var bodySubscriber = BodySubscribers.ofString(StandardCharsets.UTF_8);
+            var flowSubscriber = new StringSubscriberAdapter(bodySubscriber);
+            p.subscribe(flowSubscriber);
+            return bodySubscriber.getBody().toCompletableFuture().join();
+        }).orElse(null);
+    }
+
+    private static final class StringSubscriberAdapter implements Flow.Subscriber<ByteBuffer> {
+        final BodySubscriber<String> wrapped;
+
+        StringSubscriberAdapter(BodySubscriber<String> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            wrapped.onSubscribe(subscription);
+        }
+        @Override
+        public void onNext(ByteBuffer item) { wrapped.onNext(List.of(item)); }
+        @Override
+        public void onError(Throwable throwable) { wrapped.onError(throwable); }
+        @Override
+        public void onComplete() { wrapped.onComplete(); }
+    }
+}


### PR DESCRIPTION
This PR depends on: [CleverClient PR #12](https://github.com/sashirestela/cleverclient/pull/12)

My proposed solution addresses the issue of non-fully immutable request objects in the project, such as `ChatRequest` with a mutable `stream` flag. Immutable requests are great, but mutable `stream` flag introduces the risk of reusability issues. Specifically, if such requests are sent in parallel to the OpenAI API, concurrent threads may alter the mutable flag, potentially causing unpredictable problems with the API.

My suggestion is to allow using multiple `@Body` objects within API method arguments. By merging properties from all body objects when constructing the request body, we can ensure request objects remain fully immutable (e.g., `ChatRequest`) while also allowing the passage of separate options (like a `stream` flag with the correct value) that will be merged into the HTTP request body.

In this PR, I have attempted to make all request objects immutable, and adapt all API methods accordingly.

Please let me know what you think. I am open to discussion.