### PR TITLE
url base -> base url + some minor refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <!-- Dependencies Versions -->
     <slf4j.version>[2.0.9,3.0.0)</slf4j.version>
-    <cleverclient.version>0.12.0</cleverclient.version>
+    <cleverclient.version>0.13.0</cleverclient.version>
     <lombok.version>[1.18.30,2.0.0)</lombok.version>
     <jackson.version>[2.15.2,3.0.0)</jackson.version>
     <json.schema.version>[4.31.1,5.0.0)</json.schema.version>

--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import io.github.sashirestela.cleverclient.CleverClient;
-import javax.management.ConstructorParameters;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import io.github.sashirestela.cleverclient.CleverClient;
+import javax.management.ConstructorParameters;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,223 +13,235 @@ import lombok.NonNull;
 import lombok.Setter;
 
 /**
- * The factory that generates implementations of the {@link OpenAI OpenAI}
- * interfaces.
+ * The factory that generates implementations of the {@link OpenAI OpenAI} interfaces.
  */
 @Getter
 public class SimpleOpenAI {
 
-    private static final String OPENAI_BASE_URL = "https://api.openai.com";
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
-    private static final String BEARER_AUTHORIZATION = "Bearer ";
-    private static final String END_OF_STREAM = "[DONE]";
+  static final String OPENAI_BASE_URL = "https://api.openai.com";
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
+  private static final String BEARER_AUTHORIZATION = "Bearer ";
+  private static final String END_OF_STREAM = "[DONE]";
 
-    @NonNull
-    private final String apiKey;
+  @NonNull
+  private final String apiKey;
 
-    private final String organizationId;
-    private final String baseUrl;
-    private final HttpClient httpClient;
+  private final String organizationId;
+  private final String baseUrl;
+  @Deprecated
+  private final String urlBase = null;
 
-    @Setter
-    private CleverClient cleverClient;
+  private final HttpClient httpClient;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Audios audioService;
+  @Setter
+  private CleverClient cleverClient;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.ChatCompletions chatCompletionService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Audios audioService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Completions completionService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.ChatCompletions chatCompletionService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Embeddings embeddingService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Completions completionService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Files fileService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Embeddings embeddingService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.FineTunings fineTuningService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Files fileService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Images imageService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.FineTunings fineTuningService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Models modelService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Images imageService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Moderations moderationService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Models modelService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Assistants assistantService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Moderations moderationService;
 
-    @Getter(AccessLevel.NONE)
-    private OpenAI.Threads threadService;
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Assistants assistantService;
 
-    /**
-     * Constructor used to generate a builder.
-     *
-     * @param apiKey         Identifier to be used for authentication. Mandatory.
-     * @param organizationId Organization's id to be charged for usage. Optional.
-     * @param baseUrl        Host's url, If not provided, it'll be
-     *                       <a href="https://api.openai.com">...</a>. Optional.
-     * @param httpClient     A {@link HttpClient HttpClient} object.
-     *                       One is created by default if not provided. Optional.
-     */
-    @Builder
-    public SimpleOpenAI(String apiKey, String organizationId, String baseUrl, HttpClient httpClient) {
-        this.apiKey = apiKey;
-        this.organizationId = organizationId;
-        this.baseUrl = Optional.ofNullable(baseUrl).orElse(OPENAI_BASE_URL);
-        this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
+  @Getter(AccessLevel.NONE)
+  private OpenAI.Threads threadService;
 
-        var headers = new ArrayList<String>();
-        headers.add(AUTHORIZATION_HEADER);
-        headers.add(BEARER_AUTHORIZATION + apiKey);
-        if (organizationId != null) {
-            headers.add(ORGANIZATION_HEADER);
-            headers.add(organizationId);
-        }
-        this.cleverClient = CleverClient.builder()
-                .httpClient(this.httpClient)
-                .urlBase(this.baseUrl)
-                .headers(headers)
-                .endOfStream(END_OF_STREAM)
-                .build();
+  /**
+   * Constructor used to generate a builder.
+   *
+   * @param apiKey         Identifier to be used for authentication. Mandatory.
+   * @param organizationId Organization's id to be charged for usage. Optional.
+   * @param baseUrl        Host's url, If not provided (including via the deprecated
+   *                       urlBase), it'll be
+   *                       <a href="https://api.openai.com">...</a>. Optional.
+   * @param urlBase        [[ Deprecated ]] Host's url. See baseUrl. urlBase will
+   *                       be removed in a future version. Optional.
+   * @param httpClient     A {@link HttpClient HttpClient} object. One is created by default if not
+   *                       provided. Optional.
+   */
+  @Builder
+  public SimpleOpenAI(
+      String apiKey,
+      String organizationId,
+      String baseUrl,
+      String urlBase,
+      HttpClient httpClient) {
+    this.apiKey = apiKey;
+    this.organizationId = organizationId;
+
+    this.baseUrl = Optional.ofNullable(baseUrl)
+                           .orElse(Optional.ofNullable(urlBase).orElse(OPENAI_BASE_URL));
+
+    this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
+
+    var headers = new ArrayList<String>();
+    headers.add(AUTHORIZATION_HEADER);
+    headers.add(BEARER_AUTHORIZATION + apiKey);
+    if (organizationId != null) {
+      headers.add(ORGANIZATION_HEADER);
+      headers.add(organizationId);
     }
+    this.cleverClient = CleverClient.builder()
+        .httpClient(this.httpClient)
+        .baseUrl(this.baseUrl)
+        .headers(headers)
+        .endOfStream(END_OF_STREAM)
+        .build();
+  }
 
-    /**
-     * Generates an implementation of the Audios interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Audios audios() {
-        if (audioService == null) {
-            audioService = cleverClient.create(OpenAI.Audios.class);
-        }
-        return audioService;
+  /**
+   * Generates an implementation of the Audios interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Audios audios() {
+    if (audioService == null) {
+      audioService = cleverClient.create(OpenAI.Audios.class);
     }
+    return audioService;
+  }
 
-    /**
-     * Generates an implementation of the ChatCompletions interface to handle
-     * requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.ChatCompletions chatCompletions() {
-        if (chatCompletionService == null) {
-            chatCompletionService = cleverClient.create(OpenAI.ChatCompletions.class);
-        }
-        return chatCompletionService;
+  /**
+   * Generates an implementation of the ChatCompletions interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.ChatCompletions chatCompletions() {
+    if (chatCompletionService == null) {
+      chatCompletionService = cleverClient.create(OpenAI.ChatCompletions.class);
     }
+    return chatCompletionService;
+  }
 
-    /**
-     * Generates an implementation of the Completions interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Completions completions() {
-        if (completionService == null) {
-            completionService = cleverClient.create(OpenAI.Completions.class);
-        }
-        return completionService;
+  /**
+   * Generates an implementation of the Completions interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Completions completions() {
+    if (completionService == null) {
+      completionService = cleverClient.create(OpenAI.Completions.class);
     }
+    return completionService;
+  }
 
-    /**
-     * Generates an implementation of the Embeddings interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Embeddings embeddings() {
-        if (embeddingService == null) {
-            embeddingService = cleverClient.create(OpenAI.Embeddings.class);
-        }
-        return embeddingService;
+  /**
+   * Generates an implementation of the Embeddings interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Embeddings embeddings() {
+    if (embeddingService == null) {
+      embeddingService = cleverClient.create(OpenAI.Embeddings.class);
     }
+    return embeddingService;
+  }
 
-    /**
-     * Generates an implementation of the Files interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Files files() {
-        if (fileService == null) {
-            fileService = cleverClient.create(OpenAI.Files.class);
-        }
-        return fileService;
+  /**
+   * Generates an implementation of the Files interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Files files() {
+    if (fileService == null) {
+      fileService = cleverClient.create(OpenAI.Files.class);
     }
+    return fileService;
+  }
 
-    /**
-     * Generates an implementation of the FineTunings interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.FineTunings fineTunings() {
-        if (fineTuningService == null) {
-            fineTuningService = cleverClient.create(OpenAI.FineTunings.class);
-        }
-        return fineTuningService;
+  /**
+   * Generates an implementation of the FineTunings interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.FineTunings fineTunings() {
+    if (fineTuningService == null) {
+      fineTuningService = cleverClient.create(OpenAI.FineTunings.class);
     }
+    return fineTuningService;
+  }
 
-    /**
-     * Generates an implementation of the Images interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Images images() {
-        if (imageService == null) {
-            imageService = cleverClient.create(OpenAI.Images.class);
-        }
-        return imageService;
+  /**
+   * Generates an implementation of the Images interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Images images() {
+    if (imageService == null) {
+      imageService = cleverClient.create(OpenAI.Images.class);
     }
+    return imageService;
+  }
 
-    /**
-     * Generates an implementation of the Models interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Models models() {
-        if (modelService == null) {
-            modelService = cleverClient.create(OpenAI.Models.class);
-        }
-        return modelService;
+  /**
+   * Generates an implementation of the Models interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Models models() {
+    if (modelService == null) {
+      modelService = cleverClient.create(OpenAI.Models.class);
     }
+    return modelService;
+  }
 
-    /**
-     * Generates an implementation of the Moderations interface to handle requests.
-     * 
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Moderations moderations() {
-        if (moderationService == null) {
-            moderationService = cleverClient.create(OpenAI.Moderations.class);
-        }
-        return moderationService;
+  /**
+   * Generates an implementation of the Moderations interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Moderations moderations() {
+    if (moderationService == null) {
+      moderationService = cleverClient.create(OpenAI.Moderations.class);
     }
+    return moderationService;
+  }
 
-    /**
-     * Generates an implementation of the Assistant interface to handle requests.
-     *
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Assistants assistants() {
-        if (assistantService == null) {
-            assistantService = cleverClient.create(OpenAI.Assistants.class);
-        }
-        return assistantService;
+  /**
+   * Generates an implementation of the Assistant interface to handle requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Assistants assistants() {
+    if (assistantService == null) {
+      assistantService = cleverClient.create(OpenAI.Assistants.class);
     }
+    return assistantService;
+  }
 
-    /**
-     * Spawns a single instance of the Threads interface to manage requests.
-     *
-     * @return An instance of the interface. It is created only once.
-     */
-    public OpenAI.Threads threads() {
-        if (threadService == null) {
-            threadService = cleverClient.create(OpenAI.Threads.class);
-        }
-        return threadService;
+  /**
+   * Spawns a single instance of the Threads interface to manage requests.
+   *
+   * @return An instance of the interface. It is created only once.
+   */
+  public OpenAI.Threads threads() {
+    if (threadService == null) {
+      threadService = cleverClient.create(OpenAI.Threads.class);
     }
+    return threadService;
+  }
 }

--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
@@ -17,230 +17,230 @@ import lombok.Setter;
 @Getter
 public class SimpleOpenAI {
 
-  static final String OPENAI_BASE_URL = "https://api.openai.com";
-  private static final String AUTHORIZATION_HEADER = "Authorization";
-  private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
-  private static final String BEARER_AUTHORIZATION = "Bearer ";
-  private static final String END_OF_STREAM = "[DONE]";
+    static final String OPENAI_BASE_URL = "https://api.openai.com";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
+    private static final String BEARER_AUTHORIZATION = "Bearer ";
+    private static final String END_OF_STREAM = "[DONE]";
 
-  @NonNull
-  private final String apiKey;
+    @NonNull
+    private final String apiKey;
 
-  private final String organizationId;
-  private final String baseUrl;
-  @Deprecated
-  private final String urlBase = null;
+    private final String organizationId;
+    private final String baseUrl;
+    @Deprecated
+    private final String urlBase = null;
 
-  private final HttpClient httpClient;
+    private final HttpClient httpClient;
 
-  @Setter
-  private CleverClient cleverClient;
+    @Setter
+    private CleverClient cleverClient;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Audios audioService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Audios audioService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.ChatCompletions chatCompletionService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.ChatCompletions chatCompletionService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Completions completionService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Completions completionService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Embeddings embeddingService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Embeddings embeddingService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Files fileService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Files fileService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.FineTunings fineTuningService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.FineTunings fineTuningService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Images imageService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Images imageService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Models modelService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Models modelService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Moderations moderationService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Moderations moderationService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Assistants assistantService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Assistants assistantService;
 
-  @Getter(AccessLevel.NONE)
-  private OpenAI.Threads threadService;
+    @Getter(AccessLevel.NONE)
+    private OpenAI.Threads threadService;
 
-  /**
-   * Constructor used to generate a builder.
-   *
-   * @param apiKey         Identifier to be used for authentication. Mandatory.
-   * @param organizationId Organization's id to be charged for usage. Optional.
-   * @param baseUrl        Host's url, If not provided (including via the deprecated
-   *                       urlBase), it'll be
-   *                       <a href="https://api.openai.com">...</a>. Optional.
-   * @param urlBase        [[ Deprecated ]] Host's url. See baseUrl. urlBase will
-   *                       be removed in a future version. Optional.
-   * @param httpClient     A {@link HttpClient HttpClient} object. One is created by default if not
-   *                       provided. Optional.
-   */
-  @Builder
-  public SimpleOpenAI(
-      String apiKey,
-      String organizationId,
-      String baseUrl,
-      String urlBase,
-      HttpClient httpClient) {
-    this.apiKey = apiKey;
-    this.organizationId = organizationId;
+    /**
+     * Constructor used to generate a builder.
+     *
+     * @param apiKey         Identifier to be used for authentication. Mandatory.
+     * @param organizationId Organization's id to be charged for usage. Optional.
+     * @param baseUrl        Host's url, If not provided (including via the deprecated urlBase),
+     *                       it'll be
+     *                       <a href="https://api.openai.com">...</a>. Optional.
+     * @param urlBase        [[ Deprecated ]] Host's url. See baseUrl. urlBase will be removed in a
+     *                       future version. Optional.
+     * @param httpClient     A {@link HttpClient HttpClient} object. One is created by default if
+     *                       not provided. Optional.
+     */
+    @Builder
+    public SimpleOpenAI(
+        String apiKey,
+        String organizationId,
+        String baseUrl,
+        String urlBase,
+        HttpClient httpClient) {
+        this.apiKey = apiKey;
+        this.organizationId = organizationId;
 
-    this.baseUrl = Optional.ofNullable(baseUrl)
-                           .orElse(Optional.ofNullable(urlBase).orElse(OPENAI_BASE_URL));
+        this.baseUrl = Optional.ofNullable(baseUrl)
+            .orElse(Optional.ofNullable(urlBase).orElse(OPENAI_BASE_URL));
 
-    this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
+        this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
 
-    var headers = new ArrayList<String>();
-    headers.add(AUTHORIZATION_HEADER);
-    headers.add(BEARER_AUTHORIZATION + apiKey);
-    if (organizationId != null) {
-      headers.add(ORGANIZATION_HEADER);
-      headers.add(organizationId);
+        var headers = new ArrayList<String>();
+        headers.add(AUTHORIZATION_HEADER);
+        headers.add(BEARER_AUTHORIZATION + apiKey);
+        if (organizationId != null) {
+            headers.add(ORGANIZATION_HEADER);
+            headers.add(organizationId);
+        }
+        this.cleverClient = CleverClient.builder()
+            .httpClient(this.httpClient)
+            .baseUrl(this.baseUrl)
+            .headers(headers)
+            .endOfStream(END_OF_STREAM)
+            .build();
     }
-    this.cleverClient = CleverClient.builder()
-        .httpClient(this.httpClient)
-        .baseUrl(this.baseUrl)
-        .headers(headers)
-        .endOfStream(END_OF_STREAM)
-        .build();
-  }
 
-  /**
-   * Generates an implementation of the Audios interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Audios audios() {
-    if (audioService == null) {
-      audioService = cleverClient.create(OpenAI.Audios.class);
+    /**
+     * Generates an implementation of the Audios interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Audios audios() {
+        if (audioService == null) {
+            audioService = cleverClient.create(OpenAI.Audios.class);
+        }
+        return audioService;
     }
-    return audioService;
-  }
 
-  /**
-   * Generates an implementation of the ChatCompletions interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.ChatCompletions chatCompletions() {
-    if (chatCompletionService == null) {
-      chatCompletionService = cleverClient.create(OpenAI.ChatCompletions.class);
+    /**
+     * Generates an implementation of the ChatCompletions interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.ChatCompletions chatCompletions() {
+        if (chatCompletionService == null) {
+            chatCompletionService = cleverClient.create(OpenAI.ChatCompletions.class);
+        }
+        return chatCompletionService;
     }
-    return chatCompletionService;
-  }
 
-  /**
-   * Generates an implementation of the Completions interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Completions completions() {
-    if (completionService == null) {
-      completionService = cleverClient.create(OpenAI.Completions.class);
+    /**
+     * Generates an implementation of the Completions interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Completions completions() {
+        if (completionService == null) {
+            completionService = cleverClient.create(OpenAI.Completions.class);
+        }
+        return completionService;
     }
-    return completionService;
-  }
 
-  /**
-   * Generates an implementation of the Embeddings interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Embeddings embeddings() {
-    if (embeddingService == null) {
-      embeddingService = cleverClient.create(OpenAI.Embeddings.class);
+    /**
+     * Generates an implementation of the Embeddings interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Embeddings embeddings() {
+        if (embeddingService == null) {
+            embeddingService = cleverClient.create(OpenAI.Embeddings.class);
+        }
+        return embeddingService;
     }
-    return embeddingService;
-  }
 
-  /**
-   * Generates an implementation of the Files interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Files files() {
-    if (fileService == null) {
-      fileService = cleverClient.create(OpenAI.Files.class);
+    /**
+     * Generates an implementation of the Files interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Files files() {
+        if (fileService == null) {
+            fileService = cleverClient.create(OpenAI.Files.class);
+        }
+        return fileService;
     }
-    return fileService;
-  }
 
-  /**
-   * Generates an implementation of the FineTunings interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.FineTunings fineTunings() {
-    if (fineTuningService == null) {
-      fineTuningService = cleverClient.create(OpenAI.FineTunings.class);
+    /**
+     * Generates an implementation of the FineTunings interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.FineTunings fineTunings() {
+        if (fineTuningService == null) {
+            fineTuningService = cleverClient.create(OpenAI.FineTunings.class);
+        }
+        return fineTuningService;
     }
-    return fineTuningService;
-  }
 
-  /**
-   * Generates an implementation of the Images interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Images images() {
-    if (imageService == null) {
-      imageService = cleverClient.create(OpenAI.Images.class);
+    /**
+     * Generates an implementation of the Images interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Images images() {
+        if (imageService == null) {
+            imageService = cleverClient.create(OpenAI.Images.class);
+        }
+        return imageService;
     }
-    return imageService;
-  }
 
-  /**
-   * Generates an implementation of the Models interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Models models() {
-    if (modelService == null) {
-      modelService = cleverClient.create(OpenAI.Models.class);
+    /**
+     * Generates an implementation of the Models interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Models models() {
+        if (modelService == null) {
+            modelService = cleverClient.create(OpenAI.Models.class);
+        }
+        return modelService;
     }
-    return modelService;
-  }
 
-  /**
-   * Generates an implementation of the Moderations interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Moderations moderations() {
-    if (moderationService == null) {
-      moderationService = cleverClient.create(OpenAI.Moderations.class);
+    /**
+     * Generates an implementation of the Moderations interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Moderations moderations() {
+        if (moderationService == null) {
+            moderationService = cleverClient.create(OpenAI.Moderations.class);
+        }
+        return moderationService;
     }
-    return moderationService;
-  }
 
-  /**
-   * Generates an implementation of the Assistant interface to handle requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Assistants assistants() {
-    if (assistantService == null) {
-      assistantService = cleverClient.create(OpenAI.Assistants.class);
+    /**
+     * Generates an implementation of the Assistant interface to handle requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Assistants assistants() {
+        if (assistantService == null) {
+            assistantService = cleverClient.create(OpenAI.Assistants.class);
+        }
+        return assistantService;
     }
-    return assistantService;
-  }
 
-  /**
-   * Spawns a single instance of the Threads interface to manage requests.
-   *
-   * @return An instance of the interface. It is created only once.
-   */
-  public OpenAI.Threads threads() {
-    if (threadService == null) {
-      threadService = cleverClient.create(OpenAI.Threads.class);
+    /**
+     * Spawns a single instance of the Threads interface to manage requests.
+     *
+     * @return An instance of the interface. It is created only once.
+     */
+    public OpenAI.Threads threads() {
+        if (threadService == null) {
+            threadService = cleverClient.create(OpenAI.Threads.class);
+        }
+        return threadService;
     }
-    return threadService;
-  }
 }

--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * The factory that generates implementations of the {@link OpenAI OpenAI}
@@ -17,19 +18,20 @@ import lombok.NonNull;
 @Getter
 public class SimpleOpenAI {
 
-    private static final String OPENAI_URL_BASE = "https://api.openai.com";
+    private static final String OPENAI_BASE_URL = "https://api.openai.com";
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
     private static final String BEARER_AUTHORIZATION = "Bearer ";
     private static final String END_OF_STREAM = "[DONE]";
 
     @NonNull
-    private String apiKey;
+    private final String apiKey;
 
-    private String organizationId;
-    private String urlBase;
-    private HttpClient httpClient;
+    private final String organizationId;
+    private final String baseUrl;
+    private final HttpClient httpClient;
 
+    @Setter
     private CleverClient cleverClient;
 
     @Getter(AccessLevel.NONE)
@@ -67,19 +69,19 @@ public class SimpleOpenAI {
 
     /**
      * Constructor used to generate a builder.
-     * 
+     *
      * @param apiKey         Identifier to be used for authentication. Mandatory.
      * @param organizationId Organization's id to be charged for usage. Optional.
-     * @param urlBase        Host's url, If not provided, it'll be
-     *                       https://api.openai.com. Optional.
-     * @param httpClient     A {@link java.net.http.HttpClient HttpClient} object.
+     * @param baseUrl        Host's url, If not provided, it'll be
+     *                       <a href="https://api.openai.com">...</a>. Optional.
+     * @param httpClient     A {@link HttpClient HttpClient} object.
      *                       One is created by default if not provided. Optional.
      */
     @Builder
-    public SimpleOpenAI(String apiKey, String organizationId, String urlBase, HttpClient httpClient) {
+    public SimpleOpenAI(String apiKey, String organizationId, String baseUrl, HttpClient httpClient) {
         this.apiKey = apiKey;
         this.organizationId = organizationId;
-        this.urlBase = Optional.ofNullable(urlBase).orElse(OPENAI_URL_BASE);
+        this.baseUrl = Optional.ofNullable(baseUrl).orElse(OPENAI_BASE_URL);
         this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
 
         var headers = new ArrayList<String>();
@@ -91,14 +93,10 @@ public class SimpleOpenAI {
         }
         this.cleverClient = CleverClient.builder()
                 .httpClient(this.httpClient)
-                .urlBase(this.urlBase)
+                .urlBase(this.baseUrl)
                 .headers(headers)
                 .endOfStream(END_OF_STREAM)
                 .build();
-    }
-
-    public void setCleverClient(CleverClient cleverClient) {
-        this.cleverClient = cleverClient;
     }
 
     /**

--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAI.java
@@ -9,31 +9,29 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 /**
- * The factory that generates implementations of the {@link OpenAI OpenAI} interfaces.
+ * The factory that generates implementations of the {@link OpenAI OpenAI}
+ * interfaces.
  */
 @Getter
 public class SimpleOpenAI {
 
-    static final String OPENAI_BASE_URL = "https://api.openai.com";
+    public static final String OPENAI_BASE_URL = "https://api.openai.com";
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String ORGANIZATION_HEADER = "OpenAI-Organization";
     private static final String BEARER_AUTHORIZATION = "Bearer ";
     private static final String END_OF_STREAM = "[DONE]";
 
     @NonNull
-    private final String apiKey;
+    private String apiKey;
 
-    private final String organizationId;
+    private String organizationId;
     private final String baseUrl;
     @Deprecated
     private final String urlBase = null;
+    private HttpClient httpClient;
 
-    private final HttpClient httpClient;
-
-    @Setter
     private CleverClient cleverClient;
 
     @Getter(AccessLevel.NONE)
@@ -74,24 +72,23 @@ public class SimpleOpenAI {
      *
      * @param apiKey         Identifier to be used for authentication. Mandatory.
      * @param organizationId Organization's id to be charged for usage. Optional.
-     * @param baseUrl        Host's url, If not provided (including via the deprecated urlBase),
-     *                       it'll be
+     * @param baseUrl        Host's url, If not provided (including via the
+     *                       deprecated urlBase), it'll be
      *                       <a href="https://api.openai.com">...</a>. Optional.
-     * @param urlBase        [[ Deprecated ]] Host's url. See baseUrl. urlBase will be removed in a
-     *                       future version. Optional.
-     * @param httpClient     A {@link HttpClient HttpClient} object. One is created by default if
-     *                       not provided. Optional.
+     * @param urlBase        [[ Deprecated ]] Host's url. See baseUrl. urlBase will
+     *                       be removed in a future version. Optional.
+     * @param httpClient     A {@link java.net.http.HttpClient HttpClient} object.
+     *                       One is created by default if not provided. Optional.
      */
     @Builder
     public SimpleOpenAI(
-        String apiKey,
-        String organizationId,
-        String baseUrl,
-        String urlBase,
-        HttpClient httpClient) {
+            String apiKey,
+            String organizationId,
+            String baseUrl,
+            String urlBase,
+            HttpClient httpClient) {
         this.apiKey = apiKey;
         this.organizationId = organizationId;
-
         this.baseUrl = Optional.ofNullable(baseUrl)
             .orElse(Optional.ofNullable(urlBase).orElse(OPENAI_BASE_URL));
 
@@ -112,6 +109,10 @@ public class SimpleOpenAI {
             .build();
     }
 
+    public void setCleverClient(CleverClient cleverClient) {
+        this.cleverClient = cleverClient;
+    }
+
     /**
      * Generates an implementation of the Audios interface to handle requests.
      *
@@ -125,7 +126,8 @@ public class SimpleOpenAI {
     }
 
     /**
-     * Generates an implementation of the ChatCompletions interface to handle requests.
+     * Generates an implementation of the ChatCompletions interface to handle
+     * requests.
      *
      * @return An instance of the interface. It is created only once.
      */

--- a/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
+++ b/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
@@ -1,5 +1,7 @@
 package io.github.sashirestela.openai;
 
+import static io.github.sashirestela.openai.SimpleOpenAI.OPENAI_BASE_URL;
+import static java.util.concurrent.CompletableFuture.anyOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,6 +57,42 @@ class SimpleOpenAITest {
             assertEquals("apiKey", openAI.getApiKey());
             assertEquals(otherUrl, openAI.getBaseUrl());
             assertEquals(httpClient, openAI.getHttpClient());
+        }
+
+        @Test
+        void shouldSetBaseUrlWhenBuilderIsCalledWithBaseUrlOnly() {
+            var someUrl = "https://exmaple.org/api";
+            var openAI = SimpleOpenAI.builder()
+                .baseUrl(someUrl)
+                .build();
+            assertEquals(someUrl, openAI.getBaseUrl());
+        }
+
+        @Test
+        void shouldSetBaseUrlWhenBuilderIsCalledWithUrlBaseOnly() {
+            var someUrl = "https://exmaple.org/api";
+            var openAI = SimpleOpenAI.builder()
+                .urlBase(someUrl)
+                .build();
+            assertEquals(someUrl, openAI.getBaseUrl());
+        }
+
+        @Test
+        void shouldSetBaseUrlWhenBuilderIsCalledWithBothBaseUrlAndUrlBase() {
+            var someUrl = "https://exmaple.org/api";
+            var otherUrl = "https://exmaple.org/other-api";
+            var openAI = SimpleOpenAI.builder()
+                .baseUrl(someUrl)
+                .urlBase(otherUrl)
+                .build();
+            assertEquals(someUrl, openAI.getBaseUrl());
+        }
+
+        @Test
+        void shouldSetDefaultBaseUrlWhenBuilderIsCalledWithoutBaseUrlOrUrlBase() {
+            var openAI = SimpleOpenAI.builder()
+                .build();
+            assertEquals(OPENAI_BASE_URL, openAI.getBaseUrl());
         }
 
         @Test

--- a/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
+++ b/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
@@ -1,7 +1,6 @@
 package io.github.sashirestela.openai;
 
 import static io.github.sashirestela.openai.SimpleOpenAI.OPENAI_BASE_URL;
-import static java.util.concurrent.CompletableFuture.anyOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
+++ b/src/test/java/io/github/sashirestela/openai/SimpleOpenAITest.java
@@ -40,7 +40,7 @@ class SimpleOpenAITest {
                     .apiKey("apiKey")
                     .build();
             assertEquals(HttpClient.Version.HTTP_2, openAI.getHttpClient().version());
-            assertNotNull(openAI.getUrlBase());
+            assertNotNull(openAI.getBaseUrl());
             assertNotNull(openAI.getCleverClient());
         }
 
@@ -49,11 +49,11 @@ class SimpleOpenAITest {
             var otherUrl = "https://openai.com/api";
             var openAI = SimpleOpenAI.builder()
                     .apiKey("apiKey")
-                    .urlBase(otherUrl)
+                    .baseUrl(otherUrl)
                     .httpClient(httpClient)
                     .build();
             assertEquals("apiKey", openAI.getApiKey());
-            assertEquals(otherUrl, openAI.getUrlBase());
+            assertEquals(otherUrl, openAI.getBaseUrl());
             assertEquals(httpClient, openAI.getHttpClient());
         }
 


### PR DESCRIPTION
The term "base URL" is common in the industry to describe the . See:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base

or just search for "base url".

Currently, simple-openai uses the terms urlBase and URL_BASE. This PR switches to `baseUrl` terminology with one exception for backward compatibility:

The `urlBase` field  is kept in the SimpleOpenAI class (initialized to null) so the lombok-generated Builder can still have a urlBase() method in addition to the new baseUrl().

The behavior in the constructor is as follows:

1. If only baseUrl() was called with non-empty value then this value will be used for the baseUrl field
2. If only urlBase() was called with non-empty value then this value will be used for the baseUrl field
3. If only both baseUrl() and urlBase() were called with non-empty value then the value set with baseUrl() will be used for the baseUrl field 
4. If neither of baseUrl() and urlBase() were called with non-empty value then the default OPENAI_BASE_URL is used for the baseUrl field.

The urlBase field is initialized to null and never accessed. 


The PR also includes a few minor refactorings (recommendations of IntelliJ idea).

Finally, it bumps the version of cleverclient to 0.13.0 to enjoy from a similar change.