### PR TITLE
add missing usage and temperature fields to assistant ThreadRun

### DIFF
--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/ThreadRun.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/ThreadRun.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.github.sashirestela.cleverclient.util.UnixTimestampDeserializer;
+import io.github.sashirestela.openai.domain.OpenAIUsage;
 import io.github.sashirestela.openai.domain.ToolCall;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,9 @@ public class ThreadRun {
     private List<AssistantTool> tools;
     private List<String> fileIds;
     private Map<String, String> metadata;
+    private OpenAIUsage usage;
+    private Double temperature;
+
 
     public interface Status {
 

--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/ThreadRun.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/ThreadRun.java
@@ -50,7 +50,6 @@ public class ThreadRun {
     private OpenAIUsage usage;
     private Double temperature;
 
-
     public interface Status {
 
         String QUEUED = "queued";


### PR DESCRIPTION
This fixes https://github.com/sashirestela/simple-openai/issues/68

Verified it works by running the assistant demo and checking the ThreadRun object after it reaches complete status.

![image](https://github.com/sashirestela/simple-openai/assets/1409590/784dfab2-5876-44bc-9285-12277ceebbee)
