### PR TITLE
added SchemaConverter interface for controlling Schema generation

### DIFF
--- a/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
+++ b/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
@@ -16,6 +16,7 @@ public class FunctionDef {
 
     @NonNull
     private Class<? extends Functional> functionalClass;
+
     @Builder.Default
     private SchemaConverter schemaConverter = JsonSchemaUtil.defaultConverter;
 

--- a/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
+++ b/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
@@ -1,5 +1,6 @@
 package io.github.sashirestela.openai.common.function;
 
+import io.github.sashirestela.openai.support.JsonSchemaUtil;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -15,5 +16,7 @@ public class FunctionDef {
 
     @NonNull
     private Class<? extends Functional> functionalClass;
+    @Builder.Default
+    private SchemaConverter schemaConverter = JsonSchemaUtil.defaultConverter;
 
 }

--- a/src/main/java/io/github/sashirestela/openai/common/function/SchemaConverter.java
+++ b/src/main/java/io/github/sashirestela/openai/common/function/SchemaConverter.java
@@ -1,0 +1,9 @@
+package io.github.sashirestela.openai.common.function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface SchemaConverter {
+
+    JsonNode convert(Class<?> c);
+
+}

--- a/src/main/java/io/github/sashirestela/openai/common/tool/Tool.java
+++ b/src/main/java/io/github/sashirestela/openai/common/tool/Tool.java
@@ -3,7 +3,6 @@ package io.github.sashirestela.openai.common.tool;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.sashirestela.openai.common.function.FunctionDef;
-import io.github.sashirestela.openai.support.JsonSchemaUtil;
 import io.github.sashirestela.slimvalidator.constraints.Required;
 import io.github.sashirestela.slimvalidator.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -26,7 +25,7 @@ public class Tool {
                 new ToolFunctionDef(
                         function.getName(),
                         function.getDescription(),
-                        JsonSchemaUtil.classToJsonSchema(function.getFunctionalClass())));
+                        function.getSchemaConverter().convert(function.getFunctionalClass())));
     }
 
     @AllArgsConstructor

--- a/src/main/java/io/github/sashirestela/openai/support/DefaultSchemaConverter.java
+++ b/src/main/java/io/github/sashirestela/openai/support/DefaultSchemaConverter.java
@@ -1,0 +1,46 @@
+package io.github.sashirestela.openai.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.victools.jsonschema.generator.*;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import io.github.sashirestela.openai.SimpleUncheckedException;
+import io.github.sashirestela.openai.common.function.SchemaConverter;
+
+import static io.github.sashirestela.openai.support.JsonSchemaUtil.JSON_EMPTY_CLASS;
+
+public class DefaultSchemaConverter implements SchemaConverter {
+
+    private final SchemaGenerator schemaGenerator;
+    private final ObjectMapper objectMapper;
+
+    public DefaultSchemaConverter() {
+        objectMapper = new ObjectMapper();
+        var jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+                JacksonOption.RESPECT_JSONPROPERTY_ORDER);
+        var configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
+                OptionPreset.PLAIN_JSON)
+                .with(jacksonModule)
+                .without(Option.SCHEMA_VERSION_INDICATOR);
+        var config = configBuilder.build();
+        schemaGenerator = new SchemaGenerator(config);
+    }
+
+    @Override
+    public JsonNode convert(Class<?> clazz) {
+        JsonNode jsonSchema;
+        try {
+            jsonSchema = schemaGenerator.generateSchema(clazz);
+            if (jsonSchema.get("properties") == null) {
+                jsonSchema = objectMapper.readTree(JSON_EMPTY_CLASS);
+            }
+
+        } catch (Exception e) {
+            throw new SimpleUncheckedException("Cannot generate the Json Schema for the class {0}.", clazz.getName(),
+                    e);
+        }
+        return jsonSchema;
+    }
+
+}

--- a/src/main/java/io/github/sashirestela/openai/support/JsonSchemaUtil.java
+++ b/src/main/java/io/github/sashirestela/openai/support/JsonSchemaUtil.java
@@ -1,45 +1,19 @@
 package io.github.sashirestela.openai.support;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.victools.jsonschema.generator.Option;
-import com.github.victools.jsonschema.generator.OptionPreset;
-import com.github.victools.jsonschema.generator.SchemaGenerator;
-import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
-import com.github.victools.jsonschema.generator.SchemaVersion;
-import com.github.victools.jsonschema.module.jackson.JacksonModule;
-import com.github.victools.jsonschema.module.jackson.JacksonOption;
-import io.github.sashirestela.openai.SimpleUncheckedException;
+import io.github.sashirestela.openai.common.function.SchemaConverter;
 
 public class JsonSchemaUtil {
 
+    public static final SchemaConverter defaultConverter = new DefaultSchemaConverter();
+
     public static final String JSON_EMPTY_CLASS = "{\"type\":\"object\",\"properties\":{}}";
-    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private JsonSchemaUtil() {
     }
 
     public static JsonNode classToJsonSchema(Class<?> clazz) {
-        JsonNode jsonSchema = null;
-        try {
-            var jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
-                    JacksonOption.RESPECT_JSONPROPERTY_ORDER);
-            var configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
-                    OptionPreset.PLAIN_JSON)
-                    .with(jacksonModule)
-                    .without(Option.SCHEMA_VERSION_INDICATOR);
-            var config = configBuilder.build();
-            var generator = new SchemaGenerator(config);
-            jsonSchema = generator.generateSchema(clazz);
-            if (jsonSchema.get("properties") == null) {
-                jsonSchema = objectMapper.readTree(JSON_EMPTY_CLASS);
-            }
-
-        } catch (Exception e) {
-            throw new SimpleUncheckedException("Cannot generate the Json Schema for the class {0}.",
-                    clazz.getName(), e);
-        }
-        return jsonSchema;
+        return defaultConverter.convert(clazz);
     }
 
 }

--- a/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverter.java
+++ b/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverter.java
@@ -1,0 +1,49 @@
+package io.github.sashirestela.openai.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.victools.jsonschema.generator.*;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import io.github.sashirestela.openai.SimpleUncheckedException;
+import io.github.sashirestela.openai.common.function.SchemaConverter;
+
+public class CustomSchemaConverter implements SchemaConverter {
+
+    private final SchemaGenerator schemaGenerator;
+    private final ObjectMapper objectMapper;
+    public static final String JSON_EMPTY_CLASS = "{\"type\":\"object\",\"properties\":{}}";
+
+    public CustomSchemaConverter() {
+        objectMapper = new ObjectMapper();
+        var jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+                JacksonOption.RESPECT_JSONPROPERTY_ORDER);
+        var configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
+                OptionPreset.PLAIN_JSON)
+                .with(jacksonModule)
+                .with(builder -> builder.forTypesInGeneral()
+                        .withTypeAttributeOverride(
+                                (collectedTypeAttributes, scope, context) -> collectedTypeAttributes
+                                        .put("myCustomProperty", true)))
+                .without(Option.SCHEMA_VERSION_INDICATOR);
+        var config = configBuilder.build();
+        schemaGenerator = new SchemaGenerator(config);
+    }
+
+    @Override
+    public JsonNode convert(Class<?> clazz) {
+        JsonNode jsonSchema;
+        try {
+            jsonSchema = schemaGenerator.generateSchema(clazz);
+            if (jsonSchema.get("properties") == null) {
+                jsonSchema = objectMapper.readTree(JSON_EMPTY_CLASS);
+            }
+
+        } catch (Exception e) {
+            throw new SimpleUncheckedException("Cannot generate the Json Schema for the class {0}.", clazz.getName(),
+                    e);
+        }
+        return jsonSchema;
+    }
+
+}

--- a/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverterTest.java
+++ b/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverterTest.java
@@ -1,0 +1,74 @@
+package io.github.sashirestela.openai.support;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.sashirestela.openai.common.function.SchemaConverter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.github.sashirestela.openai.support.JsonSchemaUtil.JSON_EMPTY_CLASS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomSchemaConverterTest {
+
+    private static SchemaConverter schemaConverter=new CustomSchemaConverter();
+
+
+    @Test
+    void shouldGenerateFullJsonSchemaWhenClassHasSomeFields() {
+        var actualJsonSchema = schemaConverter.convert(TestClass.class).toString();
+        var expectedJsonSchema = "{\"type\":\"object\",\"properties\":{\"first\":{\"type\":\"string\",\"myCustomProperty\":true},\"second\":{\"type\":\"integer\",\"myCustomProperty\":true}},\"required\":[\"first\"],\"myCustomProperty\":true}";
+        assertEquals(expectedJsonSchema, actualJsonSchema);
+    }
+
+    @Test
+    void shouldGenerateEmptyJsonSchemaWhenClassHasNoFields() {
+        var actualJsonSchema = schemaConverter.convert(EmptyClass.class).toString();
+        var expectedJsonSchema = JSON_EMPTY_CLASS;
+        assertEquals(expectedJsonSchema, actualJsonSchema);
+    }
+
+    @Test
+    void shouldGenerateOrderedJsonSchemaWhenClassHasJsonPropertyOrderAnnotation() {
+        var actualJsonSchema = schemaConverter.convert(OrderedTestClass.class).toString();
+        var expectedJsonSchema = "{\"type\":\"object\",\"properties\":{\"first\":{\"type\":\"string\",\"myCustomProperty\":true},\"second\":{\"type\":\"integer\",\"myCustomProperty\":true},\"third\":{\"type\":\"string\",\"myCustomProperty\":true}},\"required\":[\"first\"],\"myCustomProperty\":true}";
+        assertEquals(expectedJsonSchema, actualJsonSchema);
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    static class TestClass {
+
+        @JsonProperty(required = true)
+        public String first;
+
+        public Integer second;
+
+    }
+
+    static class EmptyClass {
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @JsonPropertyOrder({ "first", "second", "third" })
+    static class OrderedTestClass {
+
+        @JsonProperty(required = true)
+        public String first;
+
+        public Integer second;
+
+        public String third;
+
+    }
+
+
+
+}

--- a/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverterTest.java
+++ b/src/test/java/io/github/sashirestela/openai/support/CustomSchemaConverterTest.java
@@ -2,12 +2,10 @@ package io.github.sashirestela.openai.support;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.github.sashirestela.openai.common.function.SchemaConverter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.github.sashirestela.openai.support.JsonSchemaUtil.JSON_EMPTY_CLASS;
@@ -15,8 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CustomSchemaConverterTest {
 
-    private static SchemaConverter schemaConverter=new CustomSchemaConverter();
-
+    private static SchemaConverter schemaConverter = new CustomSchemaConverter();
 
     @Test
     void shouldGenerateFullJsonSchemaWhenClassHasSomeFields() {
@@ -68,7 +65,5 @@ class CustomSchemaConverterTest {
         public String third;
 
     }
-
-
 
 }


### PR DESCRIPTION
solves #159 

1.added `SchemaConverter `interface for controlling Schema generation
2.added `DefaultSchemaConverter `for running the default (same logic that we had before in `JsonSchemaUtil`) - note this also improves performance as previously schema creator was created per serialization
3. `JsonSchemaUtil `is not really necessary anymore but kept to be compatible; 
