### PR TITLE
Add strict option to FunctionDef

### DIFF
--- a/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
+++ b/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
@@ -1,5 +1,6 @@
 package io.github.sashirestela.openai.common.function;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.sashirestela.openai.support.JsonSchemaUtil;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,10 +15,19 @@ public class FunctionDef {
 
     private String description;
 
+    private boolean strict;
+
     @NonNull
     private Class<? extends Functional> functionalClass;
 
     @Builder.Default
-    private SchemaConverter schemaConverter = JsonSchemaUtil.defaultConverter;
+    private SchemaConverter schemaConverter = converterWithAdditionalProperties;
+
+    private static final SchemaConverter converterWithAdditionalProperties = c -> {
+        var jsonNode = JsonSchemaUtil.defaultConverter.convert(c);
+        // Ref: https://platform.openai.com/docs/guides/structured-outputs/additionalproperties-false-must-always-be-set-in-objects
+        ((ObjectNode) jsonNode).put("additionalProperties", false);
+        return jsonNode;
+    };
 
 }

--- a/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
+++ b/src/main/java/io/github/sashirestela/openai/common/function/FunctionDef.java
@@ -25,8 +25,11 @@ public class FunctionDef {
 
     private static final SchemaConverter converterWithAdditionalProperties = c -> {
         var jsonNode = JsonSchemaUtil.defaultConverter.convert(c);
+        // Default to no additional properties.
         // Ref: https://platform.openai.com/docs/guides/structured-outputs/additionalproperties-false-must-always-be-set-in-objects
-        ((ObjectNode) jsonNode).put("additionalProperties", false);
+        if (jsonNode.get("additionalProperties") == null) {
+            ((ObjectNode) jsonNode).put("additionalProperties", false);
+        }
         return jsonNode;
     };
 

--- a/src/main/java/io/github/sashirestela/openai/common/tool/Tool.java
+++ b/src/main/java/io/github/sashirestela/openai/common/tool/Tool.java
@@ -25,6 +25,7 @@ public class Tool {
                 new ToolFunctionDef(
                         function.getName(),
                         function.getDescription(),
+                        function.isStrict(),
                         function.getSchemaConverter().convert(function.getFunctionalClass())));
     }
 
@@ -40,6 +41,8 @@ public class Tool {
         private String name;
 
         private String description;
+
+        private boolean strict;
 
         @Required
         private JsonNode parameters;


### PR DESCRIPTION
Related to #170 

This PR adds the `strict` option to `FunctionDef`.
Also, all generated `parameters` schemas will default to `additionalProperties` set to `false`, since that is required for `strict` to work correctly. Sadly, I couldn't find an elegant way to set this, better ideas are welcome.