### PR TITLE
Added support for file_search/ranking_options and results responses, additional error states

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.sashirestela</groupId>
   <artifactId>simple-openai</artifactId>
-  <version>3.7.1</version>
+  <version>3.7.0</version>
   <packaging>jar</packaging>
 
   <name>simple-openai</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.sashirestela</groupId>
   <artifactId>simple-openai</artifactId>
-  <version>3.7.0</version>
+  <version>3.7.1</version>
   <packaging>jar</packaging>
 
   <name>simple-openai</name>

--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/LastError.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/LastError.java
@@ -24,6 +24,12 @@ public class LastError {
         @JsonProperty("rate_limit_exceeded")
         RATE_LIMIT_EXCEEDED,
 
+		@JsonProperty("invalid_image")
+		INVALID_IMAGE,
+
+		@JsonProperty("invalid_file")
+		INVALID_FILE,
+
         @JsonProperty("invalid_prompt")
         INVALID_PROMPT;
     }

--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.util.List;
-import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes({
@@ -144,11 +143,45 @@ public class StepDetail {
             @ToString
             @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
             public static class FileSearchToolCall extends StepToolCall {
+            	
+            	private RankingOptions rankingOptions;
+                private List<Result> results;
 
-                private Map<String, String> fileSearch;
-                private Map<String, String> rankingOptions;
+                @NoArgsConstructor
+                @Getter
+                @ToString
+                @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+                public static class RankingOptions {
 
-            }
+                    private String ranker;
+                    private Number score_threshold;
+
+                }
+
+                @NoArgsConstructor
+                @Getter
+                @ToString
+                @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+                public static class Result {
+
+                    private String file_id;
+                    private String file_name;
+                    private Number score;
+                    private List<Content> content;
+
+                    @NoArgsConstructor
+                    @Getter
+                    @ToString
+                    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+                    public static class Content {
+
+                        private String type;
+                        private String text;
+
+                    }
+                }
+
+          }
 
             @NoArgsConstructor
             @Getter

--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
@@ -143,8 +143,8 @@ public class StepDetail {
             @ToString
             @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
             public static class FileSearchToolCall extends StepToolCall {
-            	
-            	private RankingOptions rankingOptions;
+
+                private RankingOptions rankingOptions;
                 private List<Result> results;
 
                 @NoArgsConstructor
@@ -154,7 +154,7 @@ public class StepDetail {
                 public static class RankingOptions {
 
                     private String ranker;
-                    private Number score_threshold;
+                    private Number scoreThreshold;
 
                 }
 
@@ -164,8 +164,8 @@ public class StepDetail {
                 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
                 public static class Result {
 
-                    private String file_id;
-                    private String file_name;
+                    private String fileId;
+                    private String fileName;
                     private Number score;
                     private List<Content> content;
 
@@ -179,9 +179,10 @@ public class StepDetail {
                         private String text;
 
                     }
+
                 }
 
-          }
+            }
 
             @NoArgsConstructor
             @Getter

--- a/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
+++ b/src/main/java/io/github/sashirestela/openai/domain/assistant/StepDetail.java
@@ -146,6 +146,7 @@ public class StepDetail {
             public static class FileSearchToolCall extends StepToolCall {
 
                 private Map<String, String> fileSearch;
+                private Map<String, String> rankingOptions;
 
             }
 


### PR DESCRIPTION
Added support for file_search/ranking_options and file_search/results responses, additional error states.
As per: https://platform.openai.com/docs/api-reference/run-steps/step-object
