### PR TITLE
Get Gemini vertex access token at request time

### DIFF
--- a/src/main/java/io/github/sashirestela/openai/SimpleOpenAIGeminiVertex.java
+++ b/src/main/java/io/github/sashirestela/openai/SimpleOpenAIGeminiVertex.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -64,8 +65,7 @@ public class SimpleOpenAIGeminiVertex extends OpenAIProvider implements
         public ClientConfig buildConfig() {
             return ClientConfig.builder()
                     .baseUrl(baseUrl)
-                    .headers(
-                            Map.of(Constant.AUTHORIZATION_HEADER, Constant.BEARER_AUTHORIZATION + apiKeyProvider.get()))
+                    .headers(Map.of())
                     .requestInterceptor(makeRequestInterceptor())
                     .responseInterceptor(makeResponseInterceptor())
                     .objectMapper(objectMapper)
@@ -77,6 +77,11 @@ public class SimpleOpenAIGeminiVertex extends OpenAIProvider implements
             return request -> {
                 var newUrl = request.getUrl().replaceFirst(VERSION_REGEX, "/");
                 request.setUrl(newUrl);
+                var headers = new HashMap<>(request.getHeaders());
+                headers.put(
+                        Constant.AUTHORIZATION_HEADER,
+                        Constant.BEARER_AUTHORIZATION + this.apiKeyProvider.get());
+                request.setHeaders(headers);
                 return request;
             };
         }

--- a/src/test/java/io/github/sashirestela/openai/SimpleOpenAIGeminiVertexTest.java
+++ b/src/test/java/io/github/sashirestela/openai/SimpleOpenAIGeminiVertexTest.java
@@ -46,7 +46,7 @@ class SimpleOpenAIGeminiVertexTest {
         var request = HttpRequestData.builder()
                 .url(baseUrl + "/v1/chat/completions")
                 .contentType(ContentType.APPLICATION_JSON)
-                .headers(Map.of(Constant.AUTHORIZATION_HEADER, Constant.BEARER_AUTHORIZATION + "apiKey"))
+                .headers(Map.of())
                 .body("{\"messages\":[],\"model\":\"model1\",\"stream\":false}")
                 .build();
         var expectedRequest = HttpRequestData.builder()
@@ -62,6 +62,8 @@ class SimpleOpenAIGeminiVertexTest {
                 .buildConfig();
         var actualRequest = clientConfig.getRequestInterceptor().apply(request);
         assertEquals(expectedRequest.getUrl(), actualRequest.getUrl());
+        assertEquals(expectedRequest.getHeaders().get(Constant.AUTHORIZATION_HEADER),
+                actualRequest.getHeaders().get(Constant.AUTHORIZATION_HEADER));
     }
 
     @Test


### PR DESCRIPTION
previous code got the token once when it built the config. So, while the apiKeyProvider can provide a fresh token this ability wasn't utilized. This means that if the same Gemini instance is used for more than an hour its token will expire.

The new code fetches a token whenever it sends a request and if a new token is needed it will get a new token.